### PR TITLE
 Explicitly set back_quotes for code lists in the tokenize module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 ```prolog
 ?- tokenize(`\tExample  Text.`, Tokens).
-Tokens = [cntrl('\t'), word(example), spc(' '), spc(' '), word(text), punct('.')] 
+Tokens = [cntrl('\t'), word(example), spc(' '), spc(' '), word(text), punct('.')]
 
 ?- tokenize(`\tExample  Text.`, Tokens, [cntrl(false), pack(true), cased(true)]).
-Tokens = [word('Example', 1), spc(' ', 2), word('Text', 1), punct('.', 1)] 
+Tokens = [word('Example', 1), spc(' ', 2), word('Text', 1), punct('.', 1)]
 
 ?- tokenize(`\tExample  Text.`, Tokens), untokenize(Tokens, Text), format('~s~n', [Text]).
 	example  text.
 Tokens = [cntrl('\t'), word(example), spc(' '), spc(' '), word(text), punct('.')],
-Text = [9, 101, 120, 97, 109, 112, 108, 101, 32|...] 
+Text = [9, 101, 120, 97, 109, 112, 108, 101, 32|...]
 ```
 
 # Description
 
 Module `tokenize` aims to provide a straightforward tool for tokenizing text into a simple format. It is the result of a learning exercise, and it is far from perfect. If there is sufficient interest from myself or anyone else, I'll try to improve it.
 
-It is packaged as an SWI-Prolog pack, available [here](http://www.swi-prolog.org/pack/list?p=tokenize). Install it into your SWI-Prolog system with the query 
+It is packaged as an SWI-Prolog pack, available [here](http://www.swi-prolog.org/pack/list?p=tokenize). Install it into your SWI-Prolog system with the query
 
 ```prolog
 ?- pack_install(tokenize).

--- a/prolog/tokenize.pl
+++ b/prolog/tokenize.pl
@@ -25,6 +25,9 @@ text.
 
 */
 
+% Ensure we interpret backs as enclosing code lists in this module.
+:- set_prolog_flag(back_quotes, codes).
+
 %% tokenize(+Text:list(code), -Tokens:list(term)) is semidet.
 %
 %   @see tokenize/3 is called with an empty list of options: thus, with defaults.


### PR DESCRIPTION
Closes #7 