### PR TITLE
Use conventional option processing

### DIFF
--- a/prolog/tokenize_opts.pl
+++ b/prolog/tokenize_opts.pl
@@ -1,0 +1,32 @@
+:- module(tokenize_opts,
+          [process_options/3,
+           preopts_data/3,
+           postopts_data/3]).
+
+:- use_module(library(record)).
+
+% pre-processing options
+:- record preopts(
+       cased:boolean=false
+   ).
+
+% post-processing options
+:- record postopts(
+       spaces:boolean=true,
+       cntrl:boolean=true,
+       punct:boolean=true,
+       to:oneof([strings,atoms,chars,codes])=atoms,
+       pack:boolean=false
+   ).
+
+%% process_options(+Options:list(term), -PreOpts:term, -PostOpts:term) is semidet.
+%
+process_options(Options, PreOpts, PostOpts) :-
+    make_preopts(Options, PreOpts, Rest),
+    make_postopts(Rest, PostOpts, InvalidOptions),
+    throw_on_invalid_options(InvalidOptions).
+
+throw_on_invalid_options(InvalidOptions) :-
+    InvalidOptions \= []
+    -> throw(invalid_options_given(InvalidOptions))
+    ;  true.

--- a/test/test.pl
+++ b/test/test.pl
@@ -7,6 +7,8 @@
    asserta(user:file_search_path(package, PackageDir)).
 
 :- use_module(package(tokenize)).
+:- use_module(package(tokenize_opts)).
+
 :- begin_tests(tokenize).
 
 test('Hello, Tokenize!',
@@ -23,6 +25,23 @@ test('Goodbye, Tokenize!',
     string_codes(Actual, Codes),
     Expected = "Goodbye, Tokenize!".
 
+
+% OPTION PROCESSING
+
+test('process_options/3 throws on invalid options') :-
+    catch(
+        process_options([invalid(true)], _, _),
+        invalid_options_given([invalid(true)]),
+        true
+    ).
+
+test('process_options/3 sets valid options in opt records') :-
+    Options = [cased(false), spaces(false)],
+    process_options(Options, PreOpts, PostOpts),
+    preopts_data(cased, PreOpts, Cased),
+    postopts_data(spaces, PostOpts, Spaces),
+    assertion(cased:Cased == cased:false),
+    assertion(spaces:Spaces == spaces:false).
 
 % NUMBERS
 


### PR DESCRIPTION
Closes #13 

The record-based approach used here is endorsed in
https://eu.swi-prolog.org/pldoc/man?section=option

The next step is to drive new options down into the core tokenization phase. This will let us pass options to  switch on/off numbers and strings, and later to customize their behavior.